### PR TITLE
feat: errorutil first proposal

### DIFF
--- a/errorutil/README.md
+++ b/errorutil/README.md
@@ -1,0 +1,34 @@
+# errorutil
+
+This module aims to provide an error wrapper that can be commonly used in mathpresso go projects.
+
+---
+
+## Installation
+
+```bash
+$ go env -w GOPRIVATE=github.com/mathpresso/*
+$ go get https://github.com/mathpresso/go-utils/errorutil
+```
+
+## Usage
+
+```go
+// If you want to just wrap error with stack trace, simply wrap your error with .Wrap()
+return errorutil.Wrap(err)
+
+// If you want to set some cause-error for your error, simply use `.FromCause()` option
+if err != nil {
+	return errorutil.Wrap(ErrSomeStaticStuff, errorutil.FromCause(err))
+}
+```
+
+## API
+
+- `errorutil.Wrap(err error, opts ...wrapOpt) error`
+  - Wrap wraps the error with provided opts.
+- `errorutil.AutoStackTrace() wrapOpt`
+  - AutoStackTrace automatically bind caller's stacktrace to error. This makes some error-capturing module (like [sentry-go](https://github.com/getsentry/sentry-go)) can extract proper stacktrace of your error.
+  - For convenience, this option is enabled by default even if you don't include it.
+- `errorutil.FromCause(err error) wrapOpt`
+  - FromCause wrap the error with provided cause. If you Unwrap this error, provided cause will be extracted.

--- a/errorutil/cause.go
+++ b/errorutil/cause.go
@@ -5,7 +5,7 @@ type causer struct {
 }
 
 func (c *causer) Cause() error {
-	if c == nil || c.cause == nil {
+	if c == nil {
 		return nil
 	}
 	return c.cause

--- a/errorutil/cause.go
+++ b/errorutil/cause.go
@@ -1,0 +1,20 @@
+package errorutil
+
+type causer struct {
+	cause error
+}
+
+func (c *causer) Cause() error {
+	if c == nil || c.cause == nil {
+		return nil
+	}
+	return c.cause
+}
+
+// Unwrap stands for error chaining compatibility
+func (c *causer) Unwrap() error {
+	if c == nil || c.cause == nil {
+		return nil
+	}
+	return c.cause
+}

--- a/errorutil/cause.go
+++ b/errorutil/cause.go
@@ -13,8 +13,5 @@ func (c *causer) Cause() error {
 
 // Unwrap stands for error chaining compatibility
 func (c *causer) Unwrap() error {
-	if c == nil || c.cause == nil {
-		return nil
-	}
-	return c.cause
+	return c.Cause()
 }

--- a/errorutil/cause_test.go
+++ b/errorutil/cause_test.go
@@ -1,0 +1,50 @@
+package errorutil
+
+import (
+	"errors"
+	"testing"
+)
+
+var _ error = (*errorWithCause)(nil)
+
+// errorWithCause is simple custom error which includes causer
+type errorWithCause struct {
+	error
+	*causer
+}
+
+func (e errorWithCause) Error() string {
+	return e.error.Error()
+}
+
+func (e errorWithCause) Is(err error) bool {
+	return errors.Is(e.error, err)
+}
+
+func TestNestedError(t *testing.T) {
+	errRoot := errors.New("this is root error")
+	errChild := errors.New("this is child error")
+	errGrandChild := errors.New("this is grand child error")
+
+	childErr := errorWithCause{
+		error:  errChild,
+		causer: &causer{cause: errGrandChild},
+	}
+	rootErr := errorWithCause{
+		error:  errRoot,
+		causer: &causer{cause: childErr},
+	}
+
+	// Ensure child has grandchild
+	if valid := errors.Is(childErr, errGrandChild); !valid {
+		t.Error("child don't have grandchild")
+	}
+	// Ensure root has child
+	if valid := errors.Is(rootErr, errChild); !valid {
+		t.Error("root don't have child")
+	}
+	// Ensure root has grandchild
+	if valid := errors.Is(rootErr, errGrandChild); !valid {
+		t.Error("root don't have grandchild")
+	}
+}

--- a/errorutil/error.go
+++ b/errorutil/error.go
@@ -1,0 +1,76 @@
+package errorutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+var _ error = (*wrapped)(nil)
+var _ fmt.Formatter = (*wrapped)(nil)
+
+type wrapped struct {
+	err error
+	*causer
+	*traceable
+}
+
+func (w *wrapped) Error() string {
+	return w.err.Error()
+}
+
+func (w *wrapped) Is(err error) bool {
+	return errors.Is(w.err, err)
+}
+
+func (w *wrapped) Format(f fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if f.Flag('+') {
+			_, _ = fmt.Fprintf(f, "%s (caused by: %v)", w.Error(), w.Cause())
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		_, _ = io.WriteString(f, w.Error())
+	}
+}
+
+type wrapOpt func(w *wrapped)
+
+// AutoStackTrace bind stack trace from Wrap method caller to the error.
+// You don't have to provide this option, because this is used by default.
+func AutoStackTrace() wrapOpt {
+	return func(w *wrapped) {
+		w.traceable = traceableFromCallers(4)
+	}
+}
+
+// FromCause wrap the error with provided cause. If you Unwrap this error, provided cause will be extracted.
+func FromCause(err error) wrapOpt {
+	return func(w *wrapped) {
+		w.causer = &causer{cause: err}
+	}
+}
+
+// Wrap wraps the err with provided opts.
+func Wrap(err error, opts ...wrapOpt) error {
+	if err == nil {
+		return nil
+	}
+	if we, ok := err.(*wrapped); ok && len(opts) == 0 {
+		// If error is already wrapped, and no additional options provided, just return it
+		return we
+	}
+
+	w := &wrapped{err: err}
+	for _, opt := range opts {
+		opt(w)
+	}
+	if w.traceable == nil {
+		// Auto bind stack trace if not already set
+		AutoStackTrace()(w)
+	}
+
+	return w
+}

--- a/errorutil/error.go
+++ b/errorutil/error.go
@@ -15,10 +15,6 @@ type wrapped struct {
 	*traceable
 }
 
-func (w *wrapped) Error() string {
-	return w.Error()
-}
-
 func (w *wrapped) Is(err error) bool {
 	return errors.Is(w.error, err)
 }
@@ -53,7 +49,7 @@ func FromCause(err error) wrapOpt {
 	}
 }
 
-// Wrap wraps the err with provided opts.
+// Wrap wraps the error with provided opts.
 func Wrap(err error, opts ...wrapOpt) error {
 	if err == nil {
 		return nil

--- a/errorutil/error.go
+++ b/errorutil/error.go
@@ -10,17 +10,17 @@ var _ error = (*wrapped)(nil)
 var _ fmt.Formatter = (*wrapped)(nil)
 
 type wrapped struct {
-	err error
+	error
 	*causer
 	*traceable
 }
 
 func (w *wrapped) Error() string {
-	return w.err.Error()
+	return w.Error()
 }
 
 func (w *wrapped) Is(err error) bool {
-	return errors.Is(w.err, err)
+	return errors.Is(w.error, err)
 }
 
 func (w *wrapped) Format(f fmt.State, verb rune) {
@@ -63,7 +63,7 @@ func Wrap(err error, opts ...wrapOpt) error {
 		return we
 	}
 
-	w := &wrapped{err: err}
+	w := &wrapped{error: err}
 	for _, opt := range opts {
 		opt(w)
 	}

--- a/errorutil/error.go
+++ b/errorutil/error.go
@@ -34,8 +34,8 @@ func (w *wrapped) Format(f fmt.State, verb rune) {
 
 type wrapOpt func(w *wrapped)
 
-// AutoStackTrace bind stack trace from Wrap method caller to the error.
-// You don't have to provide this option, because this is used by default.
+// AutoStackTrace automatically bind caller's stacktrace to error. This makes some error-capturing module (like [sentry-go](https://github.com/getsentry/sentry-go)) can extract proper stacktrace of your error.
+// For convenience, this option is enabled by default even if you don't include it.
 func AutoStackTrace() wrapOpt {
 	return func(w *wrapped) {
 		w.traceable = traceableFromCallers(4)

--- a/errorutil/error_test.go
+++ b/errorutil/error_test.go
@@ -1,0 +1,73 @@
+package errorutil
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestErrorMethod(t *testing.T) {
+	rawErr := errors.New("test error")
+	wrappedErr := Wrap(rawErr)
+	if rawErr.Error() != wrappedErr.Error() {
+		t.Errorf(".Error() mismatch:\nexpect=%#v\ngot=%#v", rawErr, wrappedErr)
+	}
+}
+
+func TestErrorCompare(t *testing.T) {
+	rawRoot := errors.New("root error")
+	rawChild := errors.New("child error")
+
+	// wrapped error must be equal to original error
+	wrappedChild := Wrap(rawChild)
+	if !errors.Is(wrappedChild, rawChild) {
+		t.Error("wrappedChild is not rawChild")
+	}
+
+	// wrapped error with cause must be equal to both original error and original cause error
+	wrappedRoot := Wrap(rawRoot, FromCause(rawChild))
+	if !errors.Is(wrappedRoot, rawRoot) {
+		t.Error("wrappedRoot is not rawRoot")
+	}
+	if !errors.Is(wrappedRoot, rawChild) {
+		t.Error("wrappedRoot is not rawChild")
+	}
+
+	// double-wrapped error also
+	doubleWrappedRoot := Wrap(rawRoot, FromCause(wrappedChild))
+	if !errors.Is(doubleWrappedRoot, rawRoot) {
+		t.Error("doubleWrappedRoot is not rawRoot")
+	}
+	if !errors.Is(doubleWrappedRoot, rawChild) {
+		t.Error("doubleWrappedRoot is not rawChild")
+	}
+}
+
+func TestStackTraceBind(t *testing.T) {
+	// This test simulates some steps of extracting stack trace from https://github.com/getsentry/sentry-go
+	// stacktrace_test.go will ensure traceable has proper stack trace.
+	err := Wrap(errors.New("test"), AutoStackTrace())
+
+	// check has StackTrace method
+	methodStackTrace := reflect.ValueOf(err).MethodByName("StackTrace")
+	if !methodStackTrace.IsValid() {
+		t.Error("err.StackTrace() is invalid")
+		return
+	}
+
+	// ensure StackTrace method returns slice type
+	tc := methodStackTrace.Call(make([]reflect.Value, 0))[0]
+	if tc.Kind() != reflect.Slice {
+		t.Error("err.StackTrace() must return slice type")
+		return
+	}
+
+	// ensure all items of slice is uintptr type
+	for i := 0; i < tc.Len(); i++ {
+		pc := tc.Index(i)
+		if pc.Kind() != reflect.Uintptr {
+			t.Error("all items of err.StackTrace() must be uintptr")
+			return
+		}
+	}
+}

--- a/errorutil/go.mod
+++ b/errorutil/go.mod
@@ -1,0 +1,3 @@
+module errors
+
+go 1.16

--- a/errorutil/go.mod
+++ b/errorutil/go.mod
@@ -1,3 +1,3 @@
-module errors
+module errorutil
 
 go 1.16

--- a/errorutil/stacktrace.go
+++ b/errorutil/stacktrace.go
@@ -1,0 +1,171 @@
+package errorutil
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+var _ fmt.Formatter = (*frame)(nil)
+
+// Frame represents a program counter inside a stack frame.
+// For historical reasons if Frame is interpreted as a uintptr
+// its value represents the program counter + 1.
+type frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// name returns the name of this function, if known.
+func (f frame) name() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	return fn.Name()
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f frame) Format(s fmt.State, verb rune) {
+	// funcname removes the path prefix component of a function's name reported by func.Name().
+	funcname := func(name string) string {
+		i := strings.LastIndex(name, "/")
+		name = name[i+1:]
+		i = strings.Index(name, ".")
+		return name[i+1:]
+	}
+
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			_, _ = io.WriteString(s, f.name())
+			_, _ = io.WriteString(s, "\n\t")
+			_, _ = io.WriteString(s, f.file())
+		default:
+			_, _ = io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		_, _ = io.WriteString(s, strconv.Itoa(f.line()))
+	case 'n':
+		_, _ = io.WriteString(s, funcname(f.name()))
+	case 'v':
+		f.Format(s, 's')
+		_, _ = io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// MarshalText formats a stacktrace Frame as a text string. The output is the
+// same as that of fmt.Sprintf("%+v", f), but without newlines or tabs.
+func (f frame) MarshalText() ([]byte, error) {
+	name := f.name()
+	if name == "unknown" {
+		return []byte(name), nil
+	}
+	return []byte(fmt.Sprintf("%s %s:%d", name, f.file(), f.line())), nil
+}
+
+var _ fmt.Formatter = (*stackTrace)(nil)
+
+// stackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type stackTrace []frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st stackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				_, _ = io.WriteString(s, "\n")
+				f.Format(s, verb)
+			}
+		case s.Flag('#'):
+			_, _ = fmt.Fprintf(s, "%#v", []frame(st))
+		default:
+			st.formatSlice(s, verb)
+		}
+	case 's':
+		st.formatSlice(s, verb)
+	}
+}
+
+// formatSlice will format this stackTrace into the given buffer as a slice of
+// Frame, only valid when called with '%s' or '%v'.
+func (st stackTrace) formatSlice(s fmt.State, verb rune) {
+	_, _ = io.WriteString(s, "[")
+	for i, f := range st {
+		if i > 0 {
+			_, _ = io.WriteString(s, " ")
+		}
+		f.Format(s, verb)
+	}
+	_, _ = io.WriteString(s, "]")
+}
+
+// traceable is error component which contains stack trace.
+type traceable []uintptr
+
+// StackTrace provides program counters.
+// Method signature was inspired from https://github.com/pkg/errors and https://github.com/getsentry/sentry-go support this.
+func (t *traceable) StackTrace() stackTrace {
+	fs := make([]frame, len(*t))
+	for i := 0; i < len(fs); i++ {
+		fs[i] = frame((*t)[i])
+	}
+	return fs
+}
+
+// traceableFromCallers create traceable from caller's stack trace
+func traceableFromCallers(skip int) *traceable {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(skip, pcs[:])
+	var t traceable = pcs[0:n]
+	return &t
+}

--- a/errorutil/stacktrace_test.go
+++ b/errorutil/stacktrace_test.go
@@ -1,0 +1,77 @@
+package errorutil
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func simpleTraceable(s int) *traceable {
+	return traceableFromCallers(s)
+}
+
+func traceableFuncBuilder(s int) func() *traceable {
+	return func() *traceable {
+		return traceableFromCallers(s)
+	}
+}
+
+func traceableCallWrapper(s int) *traceable {
+	return traceableFuncBuilder(s)()
+}
+
+func checkStackTrace(t *testing.T, given *traceable, expect []string) {
+	traceString := fmt.Sprintf("%+v", given.StackTrace())
+	traceStringParts := make([]string, 0, len(expect))
+	for idx, traceLine := range strings.SplitN(strings.Trim(traceString, " \n\r\t"), "\n", len(expect)*2+1) {
+		if idx%2 != 0 {
+			continue
+		}
+		if idx >= len(expect)*2 {
+			break
+		}
+		traceStringParts = append(traceStringParts, traceLine)
+	}
+	for i := 0; i < len(expect); i++ {
+		if !strings.HasPrefix(traceStringParts[i], expect[i]) {
+			t.Errorf("stacktrace mismatch:\nexpect=%#v\ngot=%#v", expect, traceStringParts)
+			break
+		}
+	}
+}
+
+func TestProperStackTrace(t *testing.T) {
+	testCases := []struct {
+		name     string
+		runnable func() *traceable
+		pattern  []string
+	}{
+		{
+			name: "SimpleTrace",
+			runnable: func() *traceable {
+				return simpleTraceable(1)
+			},
+			pattern: []string{
+				"errorutil.traceableFromCallers",
+				"errorutil.simpleTraceable",
+				"errorutil.TestProperStackTrace.",
+			},
+		},
+		{
+			name: "NestedTrace",
+			runnable: func() *traceable {
+				return traceableCallWrapper(2)
+			},
+			pattern: []string{
+				"errorutil.traceableFuncBuilder.",
+				"errorutil.traceableCallWrapper",
+				"errorutil.TestProperStackTrace.",
+			},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			checkStackTrace(t, tt.runnable(), tt.pattern)
+		})
+	}
+}


### PR DESCRIPTION
## 목적
- errorutil은 mathpresso의 go project 들에서 공통적으로 사용할 수 있는 error wrapper를 제공함에 중점을 둡니다.

## 방향성
- https://github.com/pkg/errors 의 코드에 영감을 받았고 이 코드의 많은 부분을 참고하였으나, 단순한 forked module이 아닌 내부적으로 maintenence를 가져가는 project로 방향성을 잡고, 우리의 상황과 맞지 않은 코드 , 네이밍은 모두 변경합니다.
- static error, dynamic error 자체의 생성은 빌트인 라이브러리 (각각 `errors.New`, `fmt.Errorf` ) 에 위임합니다. 이런 부분에 대한 compatible layer를 제공하지 않습니다.
  + 일부 IDE에서 string format 함수를 pre-define 해놓고 이를 보조해주는 기능을 일부 보조하고 있어, 이를 감쌀 경우 이런 부분의 이점을 잃을 수도 있어보입니다.
  + 이런 compatible layer를 제공하는 것은 라이브러리의 책임 범위를 넓힙니다.
- `Wrap` 단일 메소드를 제공하고, 인자로 감쌀 에러와 wrapping option들을 받습니다. 편의성을 위해 별도로 옵션을 제공하지 않더라도 자동으로 caller의 stack trace를 binding 합니다.
  + 상황별로 모든 메소드를 나누는 경우 상황에 따라 wrapping을 여러번 해야하는 경우도 생기고 이런 부분이 가독성을 저해할 수 있습니다.
  + 단일 struct, method를 가져감으로써 다중 wrapping으로 손실될 수 있었던 기존의 위험성을 제거했습니다.
