### PR TITLE
Add tag maker

### DIFF
--- a/cmd/deploytag/README.md
+++ b/cmd/deploytag/README.md
@@ -1,0 +1,19 @@
+# Tag Maker
+This script creates `tag string` for deployment according to the rules defined in `lab-development` team in order to deploy.
+
+## Usage
+
+```shell
+go run cmd/deploytag/main.go --env=prod
+# prod-20220424t150839
+```
+### Options
+* `env`: Target environment to deploy.
+
+
+## Format
+`{env}-{yyyymmdd}t{hhmmss}`
+
+
+# Reference
+* [lab-development Tag Based Deployment](https://www.notion.so/mathpresso/Tag-Based-Deployment-e1391c05e65c4350b8126d6aa79093d2)

--- a/cmd/deploytag/main.go
+++ b/cmd/deploytag/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+)
+
+var env = flag.String("env", "prod", "target environment")
+
+func main() {
+	flag.Parse()
+
+	now := time.Now().UTC().Format("20060102t150405")
+	tag := fmt.Sprintf("%v-%s", *env, now)
+	fmt.Println(tag)
+}


### PR DESCRIPTION
## Summary
* `deploytag` script 추가

## Description
배포를 위한 git tag를 rule에 맞게 생성하는 script.

## Reference
* [slack-thread](https://mathpresso-workspace.slack.com/archives/C019Q9A07K2/p1650417648599129)
* [notion](https://www.notion.so/mathpresso/Tag-Based-Deployment-e1391c05e65c4350b8126d6aa79093d2)