### PR TITLE
fix: set proper namespace for errorutil mod

### DIFF
--- a/errorutil/go.mod
+++ b/errorutil/go.mod
@@ -1,3 +1,3 @@
-module errorutil
+module github.com/mathpresso/go-utils/errorutil
 
 go 1.16


### PR DESCRIPTION
related error:
```bash
❯ go get github.com/mathpresso/go-utils/errorutil       
go get: github.com/mathpresso/go-utils/errorutil@none updating to
        github.com/mathpresso/go-utils/errorutil@v0.1.0: parsing go.mod:
        module declares its path as: errorutil
                but was required as: github.com/mathpresso/go-utils/errorutil
```