### PR TITLE
feat: Enhance errorutil documentation

### DIFF
--- a/errorutil/README.md
+++ b/errorutil/README.md
@@ -1,34 +1,13 @@
 # errorutil
 
-This module aims to provide an error wrapper that can be commonly used in mathpresso go projects.
+Package errorutil provides simple error wrapper for some features. Inspired by https://github.com/pkg/errors
+
+Currently, errorutil provides error chaining mechanism with hierachy, and auto stacktrace binding.
 
 ---
 
 ## Installation
 
 ```bash
-$ go env -w GOPRIVATE=github.com/mathpresso/*
 $ go get https://github.com/mathpresso/go-utils/errorutil
 ```
-
-## Usage
-
-```go
-// If you want to just wrap error with stack trace, simply wrap your error with .Wrap()
-return errorutil.Wrap(err)
-
-// If you want to set some cause-error for your error, simply use `.FromCause()` option
-if err != nil {
-	return errorutil.Wrap(ErrSomeStaticStuff, errorutil.FromCause(err))
-}
-```
-
-## API
-
-- `errorutil.Wrap(err error, opts ...wrapOpt) error`
-  - Wrap wraps the error with provided opts.
-- `errorutil.AutoStackTrace() wrapOpt`
-  - AutoStackTrace automatically bind caller's stacktrace to error. This makes some error-capturing module (like [sentry-go](https://github.com/getsentry/sentry-go)) can extract proper stacktrace of your error.
-  - For convenience, this option is enabled by default even if you don't include it.
-- `errorutil.FromCause(err error) wrapOpt`
-  - FromCause wrap the error with provided cause. If you Unwrap this error, provided cause will be extracted.

--- a/errorutil/cause.go
+++ b/errorutil/cause.go
@@ -1,9 +1,11 @@
 package errorutil
 
+// causer provides error chaining mechanism with hierarchy
 type causer struct {
 	cause error
 }
 
+// Cause returns chained error
 func (c *causer) Cause() error {
 	if c == nil {
 		return nil

--- a/errorutil/error.go
+++ b/errorutil/error.go
@@ -1,3 +1,7 @@
+// Package errorutil provides simple error wrapper for some features.
+// Inspired by https://github.com/pkg/errors
+//
+// Currently, errorutil provides error chaining mechanism with hierachy, and auto stacktrace binding.
 package errorutil
 
 import (
@@ -9,6 +13,7 @@ import (
 var _ error = (*wrapped)(nil)
 var _ fmt.Formatter = (*wrapped)(nil)
 
+// wrapped is wrapped error with extended features
 type wrapped struct {
 	error
 	*causer
@@ -32,23 +37,6 @@ func (w *wrapped) Format(f fmt.State, verb rune) {
 	}
 }
 
-type wrapOpt func(w *wrapped)
-
-// AutoStackTrace automatically bind caller's stacktrace to error. This makes some error-capturing module (like [sentry-go](https://github.com/getsentry/sentry-go)) can extract proper stacktrace of your error.
-// For convenience, this option is enabled by default even if you don't include it.
-func AutoStackTrace() wrapOpt {
-	return func(w *wrapped) {
-		w.traceable = traceableFromCallers(4)
-	}
-}
-
-// FromCause wrap the error with provided cause. If you Unwrap this error, provided cause will be extracted.
-func FromCause(err error) wrapOpt {
-	return func(w *wrapped) {
-		w.causer = &causer{cause: err}
-	}
-}
-
 // Wrap wraps the error with provided opts.
 func Wrap(err error, opts ...wrapOpt) error {
 	if err == nil {
@@ -69,4 +57,21 @@ func Wrap(err error, opts ...wrapOpt) error {
 	}
 
 	return w
+}
+
+type wrapOpt func(w *wrapped)
+
+// AutoStackTrace automatically bind caller's stacktrace to error. This makes some error-capturing module (like https://github.com/getsentry/sentry-go) can extract proper stacktrace of your error.
+// For convenience, this option is enabled by default even if you don't include it.
+func AutoStackTrace() wrapOpt {
+	return func(w *wrapped) {
+		w.traceable = traceableFromCallers(4)
+	}
+}
+
+// FromCause wrap the error with provided cause. If you Unwrap this error, provided cause will be extracted.
+func FromCause(err error) wrapOpt {
+	return func(w *wrapped) {
+		w.causer = &causer{cause: err}
+	}
 }

--- a/errorutil/error.go
+++ b/errorutil/error.go
@@ -20,6 +20,7 @@ type wrapped struct {
 	*traceable
 }
 
+// Is implements error interface. This makes error compare works properly.
 func (w *wrapped) Is(err error) bool {
 	return errors.Is(w.error, err)
 }
@@ -37,7 +38,7 @@ func (w *wrapped) Format(f fmt.State, verb rune) {
 	}
 }
 
-// Wrap wraps the error with provided opts.
+// Wrap wraps the error with provided options.
 func Wrap(err error, opts ...wrapOpt) error {
 	if err == nil {
 		return nil
@@ -61,7 +62,7 @@ func Wrap(err error, opts ...wrapOpt) error {
 
 type wrapOpt func(w *wrapped)
 
-// AutoStackTrace automatically bind caller's stacktrace to error. This makes some error-capturing module (like https://github.com/getsentry/sentry-go) can extract proper stacktrace of your error.
+// AutoStackTrace is the option which automatically bind caller's stacktrace to error. This makes some error-capturing module (like https://github.com/getsentry/sentry-go) can extract proper stacktrace of your error.
 // For convenience, this option is enabled by default even if you don't include it.
 func AutoStackTrace() wrapOpt {
 	return func(w *wrapped) {
@@ -69,9 +70,9 @@ func AutoStackTrace() wrapOpt {
 	}
 }
 
-// FromCause wrap the error with provided cause. If you Unwrap this error, provided cause will be extracted.
-func FromCause(err error) wrapOpt {
+// FromCause is the option which wraps the error with provided cause. If you Unwrap this error, provided cause will be extracted.
+func FromCause(cause error) wrapOpt {
 	return func(w *wrapped) {
-		w.causer = &causer{cause: err}
+		w.causer = &causer{cause: cause}
 	}
 }

--- a/errorutil/example_test.go
+++ b/errorutil/example_test.go
@@ -1,0 +1,24 @@
+package errorutil_test
+
+import (
+	"errors"
+
+	"github.com/mathpresso/go-utils/errorutil"
+)
+
+// If you want to just wrap error with stack trace, simply wrap your error with .Wrap()
+func Example_simple() {
+	_ = func() error {
+		err := errors.New("some error")
+		return errorutil.Wrap(err)
+	}
+}
+
+// If you want to set some cause-error for your error, simply use .FromCause() option
+func Example_nested() {
+	_ = func() error {
+		ErrStatic := errors.New("static error")
+		causeErr := errors.New("cause error")
+		return errorutil.Wrap(ErrStatic, errorutil.FromCause(causeErr))
+	}
+}

--- a/errorutil/stacktrace_test.go
+++ b/errorutil/stacktrace_test.go
@@ -52,9 +52,9 @@ func TestProperStackTrace(t *testing.T) {
 				return simpleTraceable(1)
 			},
 			pattern: []string{
-				"errorutil.traceableFromCallers",
-				"errorutil.simpleTraceable",
-				"errorutil.TestProperStackTrace.",
+				"github.com/mathpresso/go-utils/errorutil.traceableFromCallers",
+				"github.com/mathpresso/go-utils/errorutil.simpleTraceable",
+				"github.com/mathpresso/go-utils/errorutil.TestProperStackTrace.",
 			},
 		},
 		{
@@ -63,9 +63,9 @@ func TestProperStackTrace(t *testing.T) {
 				return traceableCallWrapper(2)
 			},
 			pattern: []string{
-				"errorutil.traceableFuncBuilder.",
-				"errorutil.traceableCallWrapper",
-				"errorutil.TestProperStackTrace.",
+				"github.com/mathpresso/go-utils/errorutil.traceableFuncBuilder.",
+				"github.com/mathpresso/go-utils/errorutil.traceableCallWrapper",
+				"github.com/mathpresso/go-utils/errorutil.TestProperStackTrace.",
 			},
 		},
 	}


### PR DESCRIPTION
- Add godoc-style comment, example
    ```bash
    # You can check this with below commands
    $ go install golang.org/x/tools/cmd/godoc@latest
    $ godoc -http=:6060
    ```
- Remove detail information from readme (use godoc instead)