### PR TITLE
docs: Add Go Reference Badge in errorutil README

### DIFF
--- a/errorutil/README.md
+++ b/errorutil/README.md
@@ -1,5 +1,7 @@
 # errorutil
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/mathpresso/go-utils/errorutil.svg)](https://pkg.go.dev/github.com/mathpresso/go-utils/errorutil)
+
 Package errorutil provides simple error wrapper for some features. Inspired by https://github.com/pkg/errors
 
 Currently, errorutil provides error chaining mechanism with hierachy, and auto stacktrace binding.


### PR DESCRIPTION
Go Reference (pkg.go.dev) Badge를 errorutil README에 추가합니다.